### PR TITLE
fix(AAE-201): added user groups mapper to alfresco-aps-realm.json

### DIFF
--- a/charts/activiti-cloud-identity/alfresco-aps-realm.json
+++ b/charts/activiti-cloud-identity/alfresco-aps-realm.json
@@ -542,7 +542,7 @@
       "directAccessGrantsEnabled": true,
       "implicitFlowEnabled": true,
       "protocolMappers" : [{ 
-        "id": "5f5272d0-dd32-49ba-b1ab-ac2e6a66d4aa",
+        "id": "5f5272d0-dd32-49ba-b1ab-ac2e6a66d4ab",
         "name": "group list",
         "protocol": "openid-connect",
         "protocolMapper": "oidc-group-membership-mapper",

--- a/charts/activiti-cloud-identity/alfresco-aps-realm.json
+++ b/charts/activiti-cloud-identity/alfresco-aps-realm.json
@@ -517,7 +517,21 @@
       "redirectUris": {{ index .Values  "alfresco-identity-service" "realm" "alfresco" "client" "redirectUris" | default tuple | toJson }},
       "webOrigins": {{ index .Values  "alfresco-identity-service" "realm" "alfresco" "client" "webOrigins" | default tuple | toJson }},
       "directAccessGrantsEnabled": true,
-      "implicitFlowEnabled": true
+      "implicitFlowEnabled": true,
+      "protocolMappers" : [{ 
+        "id": "5f5272d0-dd32-49ba-b1ab-ac2e6a66d4aa",
+        "name": "group list",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-group-membership-mapper",
+        "consentRequired": false,
+        "config": {
+          "full.path": "false",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "groups",
+          "userinfo.token.claim": "true"
+         }
+      }] 
     },
     {
       "clientId": "alfresco",
@@ -526,7 +540,21 @@
       "redirectUris": {{ index .Values  "alfresco-identity-service" "realm" "alfresco" "client" "redirectUris" | default tuple | toJson }},
       "webOrigins": {{ index .Values  "alfresco-identity-service" "realm" "alfresco" "client" "webOrigins" | default tuple | toJson }},
       "directAccessGrantsEnabled": true,
-      "implicitFlowEnabled": true
+      "implicitFlowEnabled": true,
+      "protocolMappers" : [{ 
+        "id": "5f5272d0-dd32-49ba-b1ab-ac2e6a66d4aa",
+        "name": "group list",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-group-membership-mapper",
+        "consentRequired": false,
+        "config": {
+          "full.path": "false",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "groups",
+          "userinfo.token.claim": "true"
+         }
+      }] 
     },
     {
       "clientId": "modeling-service",


### PR DESCRIPTION
This PR added user group mapper claim to support extracting authenticated user group list from access token.

Part of Activiti/Activiti#2765